### PR TITLE
V23.05 Megatron-LM with mcr-dl support

### DIFF
--- a/examples/pretrain_bert.sh
+++ b/examples/pretrain_bert.sh
@@ -2,9 +2,9 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-CHECKPOINT_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/data_dir/release/mp_rank_00/model_optim_rng.pt
-VOCAB_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/data_dir/bert-large-uncased-vocab.txt
-DATA_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/Megatron-LM/my-bert_text_sentence
+CHECKPOINT_PATH=<Specify path>
+VOCAB_FILE=<Specify path to file>/bert-vocab.txt
+DATA_PATH=<Specify path and file prefix>_text_sentence
 
 BERT_ARGS="
     --num-layers 24 \

--- a/examples/pretrain_bert.sh
+++ b/examples/pretrain_bert.sh
@@ -2,9 +2,9 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-CHECKPOINT_PATH=<Specify path>
-VOCAB_FILE=<Specify path to file>/bert-vocab.txt
-DATA_PATH=<Specify path and file prefix>_text_sentence
+CHECKPOINT_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/data_dir/release/mp_rank_00/model_optim_rng.pt
+VOCAB_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/data_dir/bert-large-uncased-vocab.txt
+DATA_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/Megatron-LM/my-bert_text_sentence
 
 BERT_ARGS="
     --num-layers 24 \

--- a/examples/pretrain_gpt.sh
+++ b/examples/pretrain_gpt.sh
@@ -4,10 +4,10 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-CHECKPOINT_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/release/mp_rank_00/model_optim_rng.pt
-VOCAB_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-vocab.json
-MERGE_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-merges.txt
-DATA_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/my-gpt2_text_document
+CHECKPOINT_PATH=<Specify path>
+VOCAB_FILE=<Specify path to file>/gpt2-vocab.json
+MERGE_FILE=<Specify path to file>/gpt2-merges.txt
+DATA_PATH=<Specify path and file prefix>_text_document
 
 GPT_ARGS="
     --num-layers 24 \
@@ -54,18 +54,3 @@ torchrun pretrain_gpt.py \
     $OUTPUT_ARGS \
     --save $CHECKPOINT_PATH \
     --load $CHECKPOINT_PATH
-
-
-# mpirun_rsh --export-all -np 1 a100-01 \
-#             MV2_USE_CUDA=1 \
-#             MV2_HYBRID_BINDING_POLICY=spread \
-#             MV2_CPU_BINDING_POLICY=hybrid \
-#             MV2_USE_GDRCOPY=0 PYTHONNOUSERSITE=true \
-#             LD_PRELOAD=/home/gulhane.2/mvapich2-installation/nvidia/gdr2.3.7_cuda11.7_gcc10.3.0_latest/lib/libmpi.so \
-#             pretrain_gpt.py \
-#             $GPT_ARGS \
-#             $DATA_ARGS \
-#             $MCRDL_ARGS \
-#             $OUTPUT_ARGS \
-#             --save $CHECKPOINT_PATH \
-#             --load $CHECKPOINT_PATH

--- a/examples/pretrain_gpt.sh
+++ b/examples/pretrain_gpt.sh
@@ -4,10 +4,10 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-CHECKPOINT_PATH=<Specify path>
-VOCAB_FILE=<Specify path to file>/gpt2-vocab.json
-MERGE_FILE=<Specify path to file>/gpt2-merges.txt
-DATA_PATH=<Specify path and file prefix>_text_document
+CHECKPOINT_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/release/mp_rank_00/model_optim_rng.pt
+VOCAB_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-vocab.json
+MERGE_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-merges.txt
+DATA_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/my-gpt2_text_document
 
 GPT_ARGS="
     --num-layers 24 \

--- a/examples/pretrain_gpt.sh
+++ b/examples/pretrain_gpt.sh
@@ -42,10 +42,30 @@ OUTPUT_ARGS="
     --eval-interval 1000 \
     --eval-iters 10
 "
+MCRDL_ARGS="
+    --distributed-engine torch \
+    --distributed-backend nccl \
+"
 
 torchrun pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \
+    $MCRDL_ARGS \
     $OUTPUT_ARGS \
     --save $CHECKPOINT_PATH \
     --load $CHECKPOINT_PATH
+
+
+# mpirun_rsh --export-all -np 1 a100-01 \
+#             MV2_USE_CUDA=1 \
+#             MV2_HYBRID_BINDING_POLICY=spread \
+#             MV2_CPU_BINDING_POLICY=hybrid \
+#             MV2_USE_GDRCOPY=0 PYTHONNOUSERSITE=true \
+#             LD_PRELOAD=/home/gulhane.2/mvapich2-installation/nvidia/gdr2.3.7_cuda11.7_gcc10.3.0_latest/lib/libmpi.so \
+#             pretrain_gpt.py \
+#             $GPT_ARGS \
+#             $DATA_ARGS \
+#             $MCRDL_ARGS \
+#             $OUTPUT_ARGS \
+#             --save $CHECKPOINT_PATH \
+#             --load $CHECKPOINT_PATH

--- a/examples/pretrain_gpt_distributed.sh
+++ b/examples/pretrain_gpt_distributed.sh
@@ -20,6 +20,9 @@ NNODES=4
 WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
 JOBID=133
 
+export MASTER_ADDR=$MASTER_ADDR
+export WORLD_SIZE=$WORLD_SIZE
+
 CHECKPOINT_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/release/mp_rank_00/model_optim_rng.pt
 VOCAB_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-vocab.json
 MERGE_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-merges.txt
@@ -76,9 +79,15 @@ OUTPUT_ARGS="
     --eval-iters 10
 "
 
+MCRDL_ARGS="
+    --distributed-engine mcr_dl \
+    --distributed-backend nccl \
+"
+
 torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \
+    $MCRDL_ARGS \
     $OUTPUT_ARGS \
     --distributed-backend nccl \
     --save $CHECKPOINT_PATH \

--- a/examples/pretrain_gpt_distributed.sh
+++ b/examples/pretrain_gpt_distributed.sh
@@ -4,25 +4,42 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-GPUS_PER_NODE=8
-# Change for multinode config
-MASTER_ADDR=localhost
-MASTER_PORT=6000
-NNODES=1
-NODE_RANK=0
-WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
+# GPUS_PER_NODE=8
+# # Change for multinode config
+# MASTER_ADDR=localhost
+# MASTER_PORT=6000
+# NNODES=1
+# NODE_RANK=0
+# WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
 
-CHECKPOINT_PATH=<Specify path>
-VOCAB_FILE=<Specify path to file>/gpt2-vocab.json
-MERGE_FILE=<Specify path to file>/gpt2-merges.txt
-DATA_PATH=<Specify path and file prefix>_text_document
+GPUS_PER_NODE=2
+# Change for multinode config
+MASTER_ADDR=$1
+# MASTER_PORT=6000
+NNODES=4
+WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
+JOBID=133
+
+CHECKPOINT_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/release/mp_rank_00/model_optim_rng.pt
+VOCAB_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-vocab.json
+MERGE_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-merges.txt
+DATA_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/my-gpt2_text_document
+
+# DISTRIBUTED_ARGS="
+#     --nproc_per_node $GPUS_PER_NODE \
+#     --nnodes $NNODES \
+#     --node_rank $NODE_RANK \
+#     --master_addr $MASTER_ADDR \
+#     --master_port $MASTER_PORT
+# "
+#  --rdzv_id $RANDOM \
 
 DISTRIBUTED_ARGS="
     --nproc_per_node $GPUS_PER_NODE \
     --nnodes $NNODES \
-    --node_rank $NODE_RANK \
-    --master_addr $MASTER_ADDR \
-    --master_port $MASTER_PORT
+    --rdzv_id $JOBID \
+    --rdzv_backend c10d \
+    --rdzv_endpoint $MASTER_ADDR:29500
 "
 
 GPT_ARGS="

--- a/examples/pretrain_gpt_distributed.sh
+++ b/examples/pretrain_gpt_distributed.sh
@@ -4,45 +4,30 @@
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-# GPUS_PER_NODE=8
-# # Change for multinode config
-# MASTER_ADDR=localhost
-# MASTER_PORT=6000
-# NNODES=1
-# NODE_RANK=0
-# WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
-
-GPUS_PER_NODE=2
+GPUS_PER_NODE=8
 # Change for multinode config
-MASTER_ADDR=$1
-# MASTER_PORT=6000
-NNODES=4
+MASTER_ADDR=localhost
+MASTER_PORT=6000
+NNODES=1
+NODE_RANK=0
 WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
-JOBID=133
 
-export MASTER_ADDR=$MASTER_ADDR
-export WORLD_SIZE=$WORLD_SIZE
-
-CHECKPOINT_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/release/mp_rank_00/model_optim_rng.pt
-VOCAB_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-vocab.json
-MERGE_FILE=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/gpt2-merges.txt
-DATA_PATH=/home/gulhane.2/Megatron-LM-MCR-DL/gpt_dataset_aws/my-gpt2_text_document
-
-# DISTRIBUTED_ARGS="
-#     --nproc_per_node $GPUS_PER_NODE \
-#     --nnodes $NNODES \
-#     --node_rank $NODE_RANK \
-#     --master_addr $MASTER_ADDR \
-#     --master_port $MASTER_PORT
-# "
-#  --rdzv_id $RANDOM \
+CHECKPOINT_PATH=<Specify path>
+VOCAB_FILE=<Specify path to file>/gpt2-vocab.json
+MERGE_FILE=<Specify path to file>/gpt2-merges.txt
+DATA_PATH=<Specify path and file prefix>_text_document
 
 DISTRIBUTED_ARGS="
     --nproc_per_node $GPUS_PER_NODE \
     --nnodes $NNODES \
-    --rdzv_id $JOBID \
-    --rdzv_backend c10d \
-    --rdzv_endpoint $MASTER_ADDR:29500
+    --node_rank $NODE_RANK \
+    --master_addr $MASTER_ADDR \
+    --master_port $MASTER_PORT
+"
+
+MCRDL_ARGS="
+    --distributed-engine torch \
+    --distributed-backend nccl \
 "
 
 GPT_ARGS="
@@ -79,16 +64,11 @@ OUTPUT_ARGS="
     --eval-iters 10
 "
 
-MCRDL_ARGS="
-    --distributed-engine mcr_dl \
-    --distributed-backend nccl \
-"
-
 torchrun $DISTRIBUTED_ARGS pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \
-    $MCRDL_ARGS \
     $OUTPUT_ARGS \
+    $MCRDL_ARGS \
     --distributed-backend nccl \
     --save $CHECKPOINT_PATH \
     --load $CHECKPOINT_PATH

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -35,6 +35,7 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     parser = _add_inference_args(parser)
     parser = _add_transformer_engine_args(parser)
     parser = _add_retro_args(parser)
+    parser = _add_mcr_dl_args(parser)
 
     # Custom arguments.
     if extra_args_provider is not None:
@@ -942,7 +943,7 @@ def _add_distributed_args(parser):
                        help='overlap pipeline parallel communication with forward and backward chunks',
                        dest='overlap_p2p_comm')
     group.add_argument('--distributed-backend', default='nccl',
-                       choices=['nccl', 'gloo'],
+                       choices=['nccl', 'mpi', 'gloo'],
                        help='Which backend to use for distributed training.')
     group.add_argument('--distributed-timeout-minutes', type=int, default=10,
                        help='Timeout minutes for torch.distributed.')
@@ -1224,5 +1225,13 @@ def _add_vision_args(parser):
                        help='teacher temperature')
     group.add_argument('--dino-warmup-teacher-temp-epochs', type=int, default=30,
                        help='warmup teacher temperaure epochs')
+
+    return parser
+
+def _add_mcr_dl_args(parser):
+    group = parser.add_argument_group(title='experimental')
+    group.add_argument("--distributed-engine", type=str, default='torch',
+                       choices=['mcr_dl', 'torch'],
+                       help='Distributed DL framework to use')
 
     return parser

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -8,6 +8,7 @@ import sys
 import numpy as np
 
 import torch
+import mcr_dl
 
 from megatron import update_num_microbatches
 from megatron.core import mpu, tensor_parallel
@@ -164,9 +165,10 @@ def read_metadata(tracker_filename):
         tracker_filename)
 
     # Get the max iteration retrieved across the ranks.
-    if torch.distributed.is_initialized():
+    dist = mcr_dl.get_distributed_engine()
+    if dist.is_initialized():
         iters_cuda = torch.cuda.LongTensor([iteration])
-        torch.distributed.all_reduce(iters_cuda, op=torch.distributed.ReduceOp.MAX)
+        dist.all_reduce(iters_cuda, op=dist.ReduceOp.MAX)
         max_iter = iters_cuda[0].item()
 
         # We should now have all the same iteration.
@@ -196,12 +198,13 @@ def get_rng_state():
         'rng_tracker_states': tensor_parallel.get_cuda_rng_tracker().get_states()}
 
     rng_state_list = None
-    if torch.distributed.is_initialized() and \
+    dist = mcr_dl.get_distributed_engine()
+    if dist.is_initialized() and \
             mpu.get_data_parallel_world_size() > 1 and \
             args.data_parallel_random_init:
         rng_state_list = \
             [None for i in range(mpu.get_data_parallel_world_size())]
-        torch.distributed.all_gather_object(
+        dist.all_gather_object(
             rng_state_list,
             rng_state,
             group=mpu.get_data_parallel_group())
@@ -235,7 +238,8 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler):
         optimizer.save_parameter_state(optim_checkpoint_name)
 
     # Collect args, model, RNG.
-    if not torch.distributed.is_initialized() \
+    dist = mcr_dl.get_distributed_engine()
+    if not dist.is_initialized() \
        or mpu.get_data_parallel_rank() == 0:
 
         # Arguments, iteration, and model.
@@ -268,22 +272,22 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler):
         torch.save(state_dict, checkpoint_name)
 
     # Wait so everyone is done (necessary)
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+    if dist.is_initialized():
+        dist.barrier()
 
     print_rank_0('  successfully saved checkpoint at iteration {:7d} to {}' \
                  .format(iteration, args.save))
 
     # And update the latest iteration
-    if not torch.distributed.is_initialized() \
-       or torch.distributed.get_rank() == 0:
+    if not dist.is_initialized() \
+       or dist.get_rank() == 0:
         tracker_filename = get_checkpoint_tracker_filename(args.save)
         with open(tracker_filename, 'w') as f:
             f.write(str(iteration))
 
     # Wait so everyone is done (not necessary)
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+    if dist.is_initialized():
+        dist.barrier()
 
 
 def _transpose_first_dim(t, num_splits, num_splits_first, model):
@@ -509,7 +513,8 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
         # Conditionally exit at this point.
         if args.exit_on_missing_checkpoint:
             print_rank_0(">> '--exit-on-missing-checkpoint' set ... exiting. <<")
-            torch.distributed.barrier()
+            dist = mcr_dl.get_distributed_engine()
+            dist.barrier()
             sys.exit()
 
         # Iteration defaults to 0.
@@ -631,8 +636,8 @@ def load_checkpoint(model, optimizer, opt_param_scheduler, load_arg='load', stri
             sys.exit()
 
     # Some utilities want to load a checkpoint without distributed being initialized
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+    if dist.is_initialized():
+        dist.barrier()
 
     print_rank_0(f'  successfully loaded checkpoint from {args.load} '
                  f'at iteration {iteration}')
@@ -660,10 +665,10 @@ def load_biencoder_checkpoint(model, only_query_model=False,
     checkpoint_name = get_checkpoint_name(load_path, iteration,
                                           args.use_distributed_optimizer,
                                           release=False)
-
+    dist = mcr_dl.get_distributed_engine()
     if mpu.get_data_parallel_rank() == 0:
         print('global rank {} is loading checkpoint {}'.format(
-            torch.distributed.get_rank(), checkpoint_name))
+            dist.get_rank(), checkpoint_name))
 
     state_dict = torch.load(model_checkpoint_name, map_location='cpu')
     ret_state_dict = state_dict['model']
@@ -675,7 +680,7 @@ def load_biencoder_checkpoint(model, only_query_model=False,
 
     assert len(model) == 1
     model[0].load_state_dict(ret_state_dict)
-    torch.distributed.barrier()
+    dist.barrier()
 
     if mpu.get_data_parallel_rank() == 0:
         print(' successfully loaded {}'.format(checkpoint_name))

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -168,11 +168,12 @@ def initialize_model_parallel(
             all_data_parallel_group_ranks.append(list(ranks))
             group = dist.new_group(ranks)
             args = get_args()
-            if not torch.distributed.is_initialized():
-                torch.distributed.init_process_group(
-                    backend=args.distributed_backend,
+            if not dist.is_initialized():
+                dist.init_processes(
+                    dist_backend=args.distributed_backend,
                     world_size=args.world_size, rank=args.rank)
-            group_gloo = torch.distributed.new_group(ranks, backend="gloo")
+
+            group_gloo = dist.new_group(ranks)
             if rank in ranks:
                 _DATA_PARALLEL_GROUP = group
                 _DATA_PARALLEL_GROUP_GLOO = group_gloo

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -3,9 +3,11 @@
 """Model and data parallel groups."""
 
 import torch
+import mcr_dl
 from typing import Optional
 
 from .utils import GlobalMemoryBuffer
+from megatron import get_args
 
 # Intra-layer model parallel group that the current rank belongs to.
 _TENSOR_MODEL_PARALLEL_GROUP = None
@@ -119,8 +121,9 @@ def initialize_model_parallel(
 
     """
     # Get world size and rank. Ensure some consistencies.
-    assert torch.distributed.is_initialized()
-    world_size: int = torch.distributed.get_world_size()
+    dist = mcr_dl.get_distributed_engine()
+    assert dist.is_initialized()
+    world_size: int = dist.get_world_size()
 
     if world_size % (tensor_model_parallel_size * pipeline_model_parallel_size) != 0:
         raise RuntimeError(
@@ -148,7 +151,8 @@ def initialize_model_parallel(
         global _PIPELINE_MODEL_PARALLEL_SPLIT_RANK
         _PIPELINE_MODEL_PARALLEL_SPLIT_RANK = pipeline_model_parallel_split_rank
 
-    rank = torch.distributed.get_rank()
+    rank = dist.get_rank()
+
 
     # Build the data-parallel groups.
     global _DATA_PARALLEL_GROUP
@@ -162,7 +166,12 @@ def initialize_model_parallel(
         for j in range(tensor_model_parallel_size):
             ranks = range(start_rank + j, end_rank, tensor_model_parallel_size)
             all_data_parallel_group_ranks.append(list(ranks))
-            group = torch.distributed.new_group(ranks)
+            group = dist.new_group(ranks)
+            args = get_args()
+            if not torch.distributed.is_initialized():
+                torch.distributed.init_process_group(
+                    backend=args.distributed_backend,
+                    world_size=args.world_size, rank=args.rank)
             group_gloo = torch.distributed.new_group(ranks, backend="gloo")
             if rank in ranks:
                 _DATA_PARALLEL_GROUP = group
@@ -175,7 +184,7 @@ def initialize_model_parallel(
     for i in range(data_parallel_size):
         ranks = [data_parallel_group_ranks[i]
                  for data_parallel_group_ranks in all_data_parallel_group_ranks]
-        group = torch.distributed.new_group(ranks)
+        group = dist.new_group(ranks)
         if rank in ranks:
             _MODEL_PARALLEL_GROUP = group
 
@@ -186,7 +195,7 @@ def initialize_model_parallel(
     for i in range(num_tensor_model_parallel_groups):
         ranks = range(i * tensor_model_parallel_size,
                       (i + 1) * tensor_model_parallel_size)
-        group = torch.distributed.new_group(ranks)
+        group = dist.new_group(ranks)
         if rank in ranks:
             _TENSOR_MODEL_PARALLEL_GROUP = group
 
@@ -205,7 +214,7 @@ def initialize_model_parallel(
         'position embedding group is already initialized'
     for i in range(num_pipeline_model_parallel_groups):
         ranks = range(i, world_size, num_pipeline_model_parallel_groups)
-        group = torch.distributed.new_group(ranks)
+        group = dist.new_group(ranks)
         if rank in ranks:
             _PIPELINE_MODEL_PARALLEL_GROUP = group
             _PIPELINE_GLOBAL_RANKS = ranks
@@ -226,13 +235,13 @@ def initialize_model_parallel(
             embedding_ranks = ranks
             position_embedding_ranks = ranks
 
-        group = torch.distributed.new_group(embedding_ranks)
+        group = dist.new_group(embedding_ranks)
         if rank in embedding_ranks:
             _EMBEDDING_GROUP = group
         if rank in ranks:
             _EMBEDDING_GLOBAL_RANKS = embedding_ranks
 
-        group = torch.distributed.new_group(position_embedding_ranks)
+        group = dist.new_group(position_embedding_ranks)
         if rank in position_embedding_ranks:
             _POSITION_EMBEDDING_GROUP = group
         if rank in ranks:
@@ -249,7 +258,7 @@ def initialize_model_parallel(
             start_rank = i * amax_group_size
             end_rank = (i + 1) * amax_group_size
             ranks = range(start_rank, end_rank)
-            group = torch.distributed.new_group(ranks)
+            group = dist.new_group(ranks)
             if rank in ranks:
                 _AMAX_REDUCTION_GROUP = group
 
@@ -351,7 +360,8 @@ def get_tensor_model_parallel_world_size():
     global _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
-    return torch.distributed.get_world_size(group=get_tensor_model_parallel_group())
+    dist = mcr_dl.get_distributed_engine()
+    return dist.get_world_size(group=get_tensor_model_parallel_group())
 
 
 def get_pipeline_model_parallel_world_size():
@@ -359,7 +369,8 @@ def get_pipeline_model_parallel_world_size():
     global _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
-    return torch.distributed.get_world_size(group=get_pipeline_model_parallel_group())
+    dist = mcr_dl.get_distributed_engine()
+    return dist.get_world_size(group=get_pipeline_model_parallel_group())
 
 
 def set_tensor_model_parallel_rank(rank):
@@ -385,7 +396,8 @@ def get_tensor_model_parallel_rank():
     global _MPU_TENSOR_MODEL_PARALLEL_RANK
     if _MPU_TENSOR_MODEL_PARALLEL_RANK is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_RANK
-    return torch.distributed.get_rank(group=get_tensor_model_parallel_group())
+    dist = mcr_dl.get_distributed_engine()
+    return dist.get_rank(group=get_tensor_model_parallel_group())
 
 
 def get_pipeline_model_parallel_rank():
@@ -393,7 +405,8 @@ def get_pipeline_model_parallel_rank():
     global _MPU_PIPELINE_MODEL_PARALLEL_RANK
     if _MPU_PIPELINE_MODEL_PARALLEL_RANK is not None:
         return _MPU_PIPELINE_MODEL_PARALLEL_RANK
-    return torch.distributed.get_rank(group=get_pipeline_model_parallel_group())
+    dist = mcr_dl.get_distributed_engine()
+    return dist.get_rank(group=get_pipeline_model_parallel_group())
 
 
 def get_pipeline_model_parallel_split_rank():
@@ -426,7 +439,8 @@ def is_pipeline_last_stage(ignore_virtual=False):
 
 def is_rank_in_embedding_group(ignore_virtual=False):
     """Return true if current rank is in embedding group, False otherwise."""
-    rank = torch.distributed.get_rank()
+    dist = mcr_dl.get_distributed_engine()
+    rank = dist.get_rank()
     global _EMBEDDING_GLOBAL_RANKS
     if ignore_virtual:
         return rank in _EMBEDDING_GLOBAL_RANKS
@@ -442,7 +456,8 @@ def is_rank_in_embedding_group(ignore_virtual=False):
 
 def is_rank_in_position_embedding_group():
     """Return true if current rank is in position embedding group, False otherwise."""
-    rank = torch.distributed.get_rank()
+    dist = mcr_dl.get_distributed_engine()
+    rank = dist.get_rank()
     global _POSITION_EMBEDDING_GLOBAL_RANKS
     return rank in _POSITION_EMBEDDING_GLOBAL_RANKS
 
@@ -513,7 +528,8 @@ def set_virtual_pipeline_model_parallel_world_size(world_size):
 def get_tensor_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
     in the tensor model parallel group."""
-    global_rank = torch.distributed.get_rank()
+    dist = mcr_dl.get_distributed_engine()
+    global_rank = dist.get_rank()
     local_world_size = get_tensor_model_parallel_world_size()
     return (global_rank // local_world_size) * local_world_size
 
@@ -562,12 +578,14 @@ def get_pipeline_model_parallel_prev_rank():
 
 def get_data_parallel_world_size():
     """Return world size for the data parallel group."""
-    return torch.distributed.get_world_size(group=get_data_parallel_group())
+    dist = mcr_dl.get_distributed_engine()
+    return dist.get_world_size(group=get_data_parallel_group())
 
 
 def get_data_parallel_rank():
     """Return my rank for the data parallel group."""
-    return torch.distributed.get_rank(group=get_data_parallel_group())
+    dist = mcr_dl.get_distributed_engine()
+    return dist.get_rank(group=get_data_parallel_group())
 
 def _set_global_memory_buffer():
     """Initialize global buffer"""

--- a/megatron/core/tensor_parallel/data.py
+++ b/megatron/core/tensor_parallel/data.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
 import torch
+import mcr_dl
 
 from megatron.core.parallel_state import (
     get_tensor_model_parallel_group,
@@ -36,8 +37,9 @@ def _build_key_size_numel_dictionaries(keys, data):
 
     # Move to GPU and broadcast.
     sizes_cuda = torch.cuda.LongTensor(sizes)
-    torch.distributed.broadcast(sizes_cuda, get_tensor_model_parallel_src_rank(),
-                                group=get_tensor_model_parallel_group())
+    dist = mcr_dl.get_distributed_engine()
+    dist.broadcast(sizes_cuda, get_tensor_model_parallel_src_rank(),
+                   group=get_tensor_model_parallel_group())
 
     # Move back to cpu and unpack.
     sizes_cpu = sizes_cuda.cpu()
@@ -90,7 +92,8 @@ def broadcast_data(keys, data, datatype):
                                    dtype=datatype)
 
     # Broadcast
-    torch.distributed.broadcast(flatten_data, get_tensor_model_parallel_src_rank(),
+    dist = mcr_dl.get_distributed_engine()
+    dist.broadcast(flatten_data, get_tensor_model_parallel_src_rank(),
                                 group=get_tensor_model_parallel_group())
 
     # Unpack

--- a/megatron/core/tensor_parallel/utils.py
+++ b/megatron/core/tensor_parallel/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
 import torch
+import mcr_dl
 from typing import List, Sequence
 
 from megatron.core.utils import divide
@@ -80,7 +81,8 @@ def gather_split_1d_tensor(tensor):
     # as opposed to torch.distributed.all_gather for efficiency reasons.
     # This API calls directly NCCL all-gather versus the former does
     # internal copies and can potentially cause slow down.
-    torch.distributed._all_gather_base(gathered, tensor,
+    dist = mcr_dl.get_distributed_engine()
+    dist._all_gather_base(gathered, tensor,
                                        group=parallel_state.get_tensor_model_parallel_group())
     return gathered
 

--- a/megatron/data/biencoder_dataset_utils.py
+++ b/megatron/data/biencoder_dataset_utils.py
@@ -3,6 +3,7 @@ import time
 
 import numpy as np
 import torch
+import mcr_dl
 
 from megatron import get_args, get_tokenizer, print_rank_0
 from megatron.core import mpu, tensor_parallel
@@ -134,6 +135,8 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
     if not max_num_samples:
         max_num_samples = np.iinfo(np.int64).max - 1
 
+    dist = mcr_dl.get_distributed_engine()
+
     # Filename of the index mapping
     indexmap_filename = data_prefix
     indexmap_filename += '_{}_indexmap'.format(name)
@@ -158,7 +161,7 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         assert block_dataset.sizes.dtype == np.int32
 
         # Build samples mapping
-        verbose = torch.distributed.get_rank() == 0
+        verbose = dist.get_rank() == 0
         start_time = time.time()
         print_rank_0(' > building samples index mapping for {} ...'.format(
             name))
@@ -189,8 +192,8 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
     # device_index=rank which is not the case for model
     # parallel case
     counts = torch.cuda.LongTensor([1])
-    torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-    assert counts[0].item() == torch.distributed.get_world_size(
+    dist.all_reduce(counts, group=mpu.get_data_parallel_group())
+    assert counts[0].item() == dist.get_world_size(
         group=mpu.get_data_parallel_group())
 
     # Load indexed dataset.

--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -8,6 +8,7 @@ import time
 
 import numpy as np
 import torch
+import mcr_dl
 
 from megatron import print_rank_0
 from megatron.core import mpu
@@ -38,9 +39,10 @@ class BlendableDataset(torch.utils.data.Dataset):
             dataset_sample_index = np.zeros(self.size, dtype=np.int64)
 
             from megatron.data import helpers
+            dist = mcr_dl.get_distributed_engine()
             helpers.build_blending_indices(dataset_index, dataset_sample_index,
                                            weights, num_datasets, self.size,
-                                           torch.distributed.get_rank() == 0)
+                                           dist.get_rank() == 0)
             print_rank_0('> elapsed time for building blendable dataset indices: '
                          '{:.2f} (sec)'.format(time.time() - start_time))
             return dataset_index, dataset_sample_index
@@ -60,7 +62,8 @@ class BlendableDataset(torch.utils.data.Dataset):
             sample_index_path = os.path.join(data_cache_path, desc_hash + "_sample_index.npy")
             cache_hit = os.path.isfile(index_path) and os.path.isfile(sample_index_path)
             cache_success = True
-            if torch.distributed.get_rank() == 0 and not cache_hit:
+            dist = mcr_dl.get_distributed_engine()
+            if dist.get_rank() == 0 and not cache_hit:
                 print(' > WARNING: could not find index map files for blendable'
                       ' dataset, building indices on rank 0 ...', flush=True)
                 dataset_index, dataset_sample_index = _build_indices()
@@ -80,11 +83,11 @@ class BlendableDataset(torch.utils.data.Dataset):
 
 
             counts = torch.cuda.LongTensor([cache_success])
-            torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-            torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
+            dist.all_reduce(counts, group=mpu.get_data_parallel_group())
+            dist.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
             if counts[0].item() != (
-                torch.distributed.get_world_size() //
-                torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group())):
+                dist.get_world_size() //
+                dist.get_world_size(group=mpu.get_tensor_model_parallel_group())):
                 print_rank_0("Data index creation unsuccessful, exiting.")
                 exit()
 

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -25,6 +25,7 @@ import collections
 
 import numpy as np
 import torch
+import mcr_dl
 
 from megatron import (
     get_args,
@@ -673,7 +674,8 @@ def get_samples_mapping(indexed_dataset,
     indexmap_filename += '.npy'
 
     # Build the indexed mapping if not exist.
-    if torch.distributed.get_rank() == 0 and \
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0 and \
        not os.path.isfile(indexmap_filename):
         print(' > WARNING: could not find index map file {}, building '
               'the indices on rank 0 ...'.format(indexmap_filename))
@@ -683,7 +685,7 @@ def get_samples_mapping(indexed_dataset,
         assert indexed_dataset.sizes.dtype == np.int32
 
         # Build samples mapping
-        verbose = torch.distributed.get_rank() == 0
+        verbose = dist.get_rank() == 0
         start_time = time.time()
         print_rank_0(' > building samples index mapping for {} ...'.format(
             name))
@@ -711,11 +713,11 @@ def get_samples_mapping(indexed_dataset,
     # device_index=rank which is not the case for model
     # parallel case
     counts = torch.cuda.LongTensor([1])
-    torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-    torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
+    dist.all_reduce(counts, group=mpu.get_data_parallel_group())
+    dist.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
     assert counts[0].item() == (
-        torch.distributed.get_world_size() //
-        torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group()))
+        dist.get_world_size() //
+        dist.get_world_size(group=mpu.get_tensor_model_parallel_group()))
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(

--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -8,6 +8,7 @@ import time
 
 import numpy as np
 import torch
+import mcr_dl
 
 from megatron import print_rank_0
 from megatron.core import mpu
@@ -363,7 +364,8 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     data_cache_success = True
 
     # Build the indexed mapping if not exist.
-    if build_indices and torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if build_indices and dist.get_rank() == 0:
         print_rank_0(' > WARNING: could not find index map files, building '
                      'the indices on rank 0 ...')
 
@@ -454,11 +456,11 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
             data_cache_success = False
 
     counts = torch.cuda.LongTensor([data_cache_success])
-    torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-    torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
+    dist.all_reduce(counts, group=mpu.get_data_parallel_group())
+    dist.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())
     if counts[0].item() != (
-        torch.distributed.get_world_size() //
-        torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group())):
+        dist.get_world_size() //
+        dist.get_world_size(group=mpu.get_tensor_model_parallel_group())):
         print_rank_0("Data index creation unsuccessful, exiting.")
         exit()
 

--- a/megatron/data/realm_dataset_utils.py
+++ b/megatron/data/realm_dataset_utils.py
@@ -3,6 +3,7 @@ import time
 
 import numpy as np
 import torch
+import mcr_dl
 
 from megatron import print_rank_0
 from megatron.core import mpu, tensor_parallel
@@ -137,6 +138,7 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         indexmap_filename += '_1sentok'
     indexmap_filename += '.npy'
 
+    dist = mcr_dl.get_distributed_engine()
     # Build the indexed mapping if not exist.
     if mpu.get_data_parallel_rank() == 0 and \
             not os.path.isfile(indexmap_filename):
@@ -148,7 +150,7 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         assert block_dataset.sizes.dtype == np.int32
 
         # Build samples mapping
-        verbose = torch.distributed.get_rank() == 0
+        verbose = dist.get_rank() == 0
         start_time = time.time()
         print_rank_0(' > building samples index mapping for {} ...'.format(
             name))
@@ -179,8 +181,8 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
     # device_index=rank which is not the case for model
     # parallel case
     counts = torch.cuda.LongTensor([1])
-    torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
-    assert counts[0].item() == torch.distributed.get_world_size(
+    dist.all_reduce(counts, group=mpu.get_data_parallel_group())
+    assert counts[0].item() == dist.get_world_size(
         group=mpu.get_data_parallel_group())
 
     # Load indexed dataset.

--- a/megatron/fused_kernels/__init__.py
+++ b/megatron/fused_kernels/__init__.py
@@ -25,7 +25,7 @@ def load(args):
         cc_flag.append('arch=compute_80,code=sm_80')
         if int(bare_metal_minor) >= 7:
             cc_flag.append('-gencode')
-            cc_flag.append('arch=compute_90,code=sm_90')
+            cc_flag.append('arch=compute_80,code=sm_80')
 
     # Build path
     srcpath = pathlib.Path(__file__).parent.absolute()

--- a/megatron/indexer.py
+++ b/megatron/indexer.py
@@ -1,7 +1,7 @@
 import sys
 import time
 import torch
-import torch.distributed as dist
+import mcr_dl
 
 from megatron import get_args, print_rank_0
 from megatron.core import mpu
@@ -113,8 +113,9 @@ class IndexBuilder(object):
 
         # This process signals to finalize its shard and then synchronize with
         # the other processes
+        dist = mcr_dl.get_distributed_engine()
         self.evidence_embedder_obj.save_shard()
-        torch.distributed.barrier()
+        dist.barrier()
         del self.model
 
         # rank 0 process builds the final copy
@@ -126,4 +127,4 @@ class IndexBuilder(object):
         self.evidence_embedder_obj.clear()
 
         # complete building the final copy
-        torch.distributed.barrier()
+        dist.barrier()

--- a/megatron/memory.py
+++ b/megatron/memory.py
@@ -2,6 +2,7 @@
 
 
 import torch
+import mcr_dl
 
 
 # A dictionary of all the memory buffers allocated.
@@ -34,7 +35,8 @@ class MemoryBuffer:
 
     """
     def __init__(self, name, numel, dtype, track_usage):
-        if torch.distributed.get_rank() == 0:
+        dist = mcr_dl.get_distributed_engine()
+        if dist.get_rank() == 0:
             element_size = torch.tensor([], dtype=dtype).element_size()
             print('> building the {} memory buffer with {} num elements '
                   'and {} dtype ({:.1f} MB)...'.format(
@@ -106,7 +108,8 @@ class MemoryBuffer:
         """Print memory usage average over time. We would like this value
         to be as high as possible."""
         assert self.track_usage, 'You need to enable track usage.'
-        if torch.distributed.get_rank() == 0:
+        dist = mcr_dl.get_distributed_engine()
+        if dist.get_rank() == 0:
             print(' > usage of {} memory buffer: {:.2f} %'.format(
                 self.name, self.in_use_value * 100.0 / self.total_value),
                   flush=True)

--- a/megatron/model/biencoder_model.py
+++ b/megatron/model/biencoder_model.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import mcr_dl
 import sys
 
 from megatron import get_args, print_rank_0, get_tokenizer
@@ -194,8 +195,9 @@ class BiEncoderModel(MegatronModule):
 
         checkpoint_name = get_checkpoint_name(args.bert_load, iteration, False)
         if mpu.get_data_parallel_rank() == 0:
+            dist = mcr_dl.get_distributed_engine()
             print('global rank {} is loading BERT checkpoint {}'.format(
-                torch.distributed.get_rank(), checkpoint_name))
+                dist.get_rank(), checkpoint_name))
 
         # Load the checkpoint.
         try:

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -3,6 +3,7 @@
 """Transformer based language model."""
 
 import torch
+import mcr_dl
 import torch.nn.functional as F
 
 from megatron import get_args
@@ -212,7 +213,8 @@ class Embedding(MegatronModule):
         """
         if self.tokentype_embeddings is not None:
             raise Exception('tokentype embeddings is already initialized')
-        if torch.distributed.get_rank() == 0:
+        dist = mcr_dl.get_distributed_engine()
+        if dist.get_rank() == 0:
             print('adding embedding for {} tokentypes'.format(num_tokentypes),
                   flush=True)
         self.num_tokentypes = num_tokentypes

--- a/megatron/model/realm_model.py
+++ b/megatron/model/realm_model.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import mcr_dl
 
 from megatron import get_args, print_rank_0
 from megatron.checkpointing import get_checkpoint_tracker_filename, get_checkpoint_name
@@ -126,8 +127,9 @@ class ICTBertModel(MegatronModule):
 
         checkpoint_name = get_checkpoint_name(args.bert_load, iteration, False)
         if mpu.get_data_parallel_rank() == 0:
+            dist = mcr_dl.get_distributed_engine()
             print('global rank {} is loading checkpoint {}'.format(
-                torch.distributed.get_rank(), checkpoint_name))
+                dist.get_rank(), checkpoint_name))
 
         try:
             state_dict = torch.load(checkpoint_name, map_location='cpu')

--- a/megatron/mpu/tests/commons.py
+++ b/megatron/mpu/tests/commons.py
@@ -5,6 +5,7 @@ import os
 import random
 import numpy
 import torch
+import mcr_dl
 
 import mpu
 
@@ -53,18 +54,25 @@ def initialize_distributed(backend='nccl'):
     master_ip = os.getenv('MASTER_ADDR', 'localhost')
     master_port = os.getenv('MASTER_PORT', '6000')
     init_method += master_ip + ':' + master_port
-    torch.distributed.init_process_group(
-        backend=backend,
-        world_size=world_size,
-        rank=rank,
+    # dist = mcr_dl.get_distributed_engine()
+    # dist.init_process_group(
+    #     backend=backend,
+    #     world_size=world_size,
+    #     rank=rank,
+    #     init_method=init_method)
+    mcr_dl.init_processes(
+        dist_engine=args.distributed_engine,
+        dist_backend=args.distributed_backend,
+        world_size=world_size, rank=rank,
         init_method=init_method)
 
 
 def print_separator(message):
-    torch.distributed.barrier()
+    dist = mcr_dl.get_distributed_engine()
+    dist.barrier()
     filler_len = (78 - len(message)) // 2
     filler = '-' * filler_len
     string = '\n' + filler + ' {} '.format(message) + filler
-    if torch.distributed.get_rank() == 0:
+    if dist.get_rank() == 0:
         print(string, flush=True)
-    torch.distributed.barrier()
+    dist.barrier()

--- a/megatron/mpu/tests/test_cross_entropy.py
+++ b/megatron/mpu/tests/test_cross_entropy.py
@@ -8,6 +8,7 @@ from mpu.cross_entropy import vocab_parallel_cross_entropy
 import mpu
 import torch.nn.functional as F
 import torch
+import mcr_dl
 import random
 import sys
 sys.path.append("../..")
@@ -43,8 +44,9 @@ def mpu_cross_entropy(batch_size, seq_length, vocab_size,
 
 
 def test_cross_entropy(tensor_model_parallel_size):
+    dist = mcr_dl.get_distributed_engine()
 
-    if torch.distributed.get_rank() == 0:
+    if dist.get_rank() == 0:
         print('> testing cross entropy with model parallel size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -67,26 +69,27 @@ def test_cross_entropy(tensor_model_parallel_size):
 
     error = loss_torch.sub_(loss_mpu).abs().max()
     print('   max error in loss on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     error = grad_torch.sub_(grad_mpu).abs().max()
     print('   max error in grad on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     # Reset groups
     mpu.destroy_tensor_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 if __name__ == '__main__':
 
     initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+    dist = mcr_dl.get_distributed_engine()
+    world_size = dist.get_world_size()
 
     tensor_model_parallel_size = 1
     while tensor_model_parallel_size <= world_size:

--- a/megatron/mpu/tests/test_data.py
+++ b/megatron/mpu/tests/test_data.py
@@ -5,6 +5,7 @@ from commons import initialize_distributed
 from mpu import data as data_utils
 import mpu
 import torch
+import mcr_dl
 import functools
 import operator
 import sys
@@ -13,7 +14,8 @@ sys.path.append("../..")
 
 def test_broadcast_data(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing broadcast_data with model parallel size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -58,15 +60,16 @@ def test_broadcast_data(tensor_model_parallel_size):
     # Reset groups
     mpu.destroy_tensor_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 if __name__ == '__main__':
 
     initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+    dist = mcr_dl.get_distributed_engine()
+    world_size = dist.get_world_size()
 
     tensor_model_parallel_size = 1
     while tensor_model_parallel_size <= world_size:

--- a/megatron/mpu/tests/test_initialize.py
+++ b/megatron/mpu/tests/test_initialize.py
@@ -4,36 +4,38 @@ from commons import print_separator
 from commons import initialize_distributed
 import mpu
 import torch
+import mcr_dl
 import sys
 sys.path.append("../..")
 
 
 def test_initialize_model_parallel(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing initialize_model_parallel with size {} ...'.format(
             tensor_model_parallel_size))
     tensor_model_parallel_size_ = min(tensor_model_parallel_size,
-                               torch.distributed.get_world_size())
+                               dist.get_world_size())
     assert not mpu.model_parallel_is_initialized()
     mpu.initialize_model_parallel(tensor_model_parallel_size_)
     assert mpu.model_parallel_is_initialized()
 
     # Checks.
     def check(group, world_size, rank):
-        assert world_size == torch.distributed.get_world_size(group=group)
-        assert rank == torch.distributed.get_rank(group=group)
+        assert world_size == dist.get_world_size(group=group)
+        assert rank == dist.get_rank(group=group)
 
     # Model parallel.
     world_size = tensor_model_parallel_size_
-    rank = torch.distributed.get_rank() % tensor_model_parallel_size_
+    rank = dist.get_rank() % tensor_model_parallel_size_
     assert world_size == mpu.get_tensor_model_parallel_world_size()
     assert rank == mpu.get_tensor_model_parallel_rank()
     check(mpu.get_tensor_model_parallel_group(), world_size, rank)
 
     # Data parallel.
-    world_size = torch.distributed.get_world_size() // tensor_model_parallel_size_
-    rank = torch.distributed.get_rank() // tensor_model_parallel_size
+    world_size = dist.get_world_size() // tensor_model_parallel_size_
+    rank = dist.get_rank() // tensor_model_parallel_size
     assert world_size == mpu.get_data_parallel_world_size()
     assert rank == mpu.get_data_parallel_rank()
     check(mpu.get_data_parallel_group(), world_size, rank)
@@ -41,38 +43,40 @@ def test_initialize_model_parallel(tensor_model_parallel_size):
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 def test_get_tensor_model_parallel_src_rank(tensor_model_parallel_size_):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing get_tensor_model_parallel_src_rank with size {} ...'.format(
             tensor_model_parallel_size_))
     tensor_model_parallel_size = min(tensor_model_parallel_size_,
-                              torch.distributed.get_world_size())
+                              dist.get_world_size())
     assert not mpu.model_parallel_is_initialized()
     mpu.initialize_model_parallel(tensor_model_parallel_size)
     assert mpu.model_parallel_is_initialized()
 
     # Checks
-    src_rank = torch.distributed.get_rank() - mpu.get_tensor_model_parallel_rank()
+    src_rank = dist.get_rank() - mpu.get_tensor_model_parallel_rank()
     assert mpu.get_tensor_model_parallel_src_rank() == src_rank
 
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 if __name__ == '__main__':
 
     initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+    dist = mcr_dl.get_distributed_engine()
+    world_size = dist.get_world_size()
     tensor_model_parallel_size = 1
     while tensor_model_parallel_size <= world_size:
         print_separator('test initialize model parallel')

--- a/megatron/mpu/tests/test_layers.py
+++ b/megatron/mpu/tests/test_layers.py
@@ -8,6 +8,7 @@ import mpu
 from torch.nn.parameter import Parameter
 import torch.nn.init as init
 import torch
+import mcr_dl
 import random
 import sys
 sys.path.append("../..")
@@ -15,7 +16,8 @@ sys.path.append("../..")
 
 def test_parallel_embedding(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing parallel embedding with model parallel size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -54,16 +56,16 @@ def test_parallel_embedding(tensor_model_parallel_size):
     loss_vocab_parallel = torch.mul(output, loss_weight).sum()
     loss_vocab_parallel.backward()
 
-    torch.distributed.barrier()
+    dist.barrier()
     error = loss_parallel.sub(loss_original).abs()
     print('   error in loss (parallel) on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-12, 'error: {}'.format(error)
 
-    torch.distributed.barrier()
+    dist.barrier()
     error = loss_vocab_parallel.sub(loss_original).abs()
     print('   error in loss (vocab parallel) on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-12, 'error: {}'.format(error)
 
     weight_grad_orig = torch.split(embedding_original.weight.grad,
@@ -71,7 +73,7 @@ def test_parallel_embedding(tensor_model_parallel_size):
                                    1)[mpu.get_tensor_model_parallel_rank()]
     error = embedding_parallel.weight.grad.sub(weight_grad_orig).abs().max()
     print('   error in grad (parallel) on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-12, 'error: {}'.format(error)
 
     weight_grad_orig = torch.split(embedding_original.weight.grad,
@@ -80,21 +82,22 @@ def test_parallel_embedding(tensor_model_parallel_size):
     error = embedding_vocab_parallel.weight.grad.sub(
         weight_grad_orig).abs().max()
     print('   error in grad (vocab parallel) on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-12, 'error: {}'.format(error)
 
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 def test_initialize_affine_weight(tensor_model_parallel_size):
 
     mpu.initialize_model_parallel(tensor_model_parallel_size)
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing initialize_affine_weight with model parallel '
               'size: {}'.format(tensor_model_parallel_size))
     tensor_model_parallel_size = mpu.get_tensor_model_parallel_world_size()
@@ -124,9 +127,9 @@ def test_initialize_affine_weight(tensor_model_parallel_size):
 
     # Compare.
     error = weight.sub(my_weight).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   column parallel max error (should be zero) on global rank '
-          '{}: {}'.format(torch.distributed.get_rank(), error))
+          '{}: {}'.format(dist.get_rank(), error))
     assert error < 1.0e-6
 
     # ------------
@@ -147,16 +150,16 @@ def test_initialize_affine_weight(tensor_model_parallel_size):
 
     # Compare.
     error = weight.sub(my_weight).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   row parallel max error (should be zero) on global rank '
-          '{}: {}'.format(torch.distributed.get_rank(), error))
+          '{}: {}'.format(dist.get_rank(), error))
     assert error < 1.0e-6
 
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print(' >> passed the test :-)')
 
 
@@ -173,7 +176,8 @@ class IdentityLayer2D(torch.nn.Module):
 def test_column_parallel_linear(tensor_model_parallel_size):
 
     mpu.initialize_model_parallel(tensor_model_parallel_size)
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing ColumnParallelLinear with model parallel '
               'size: {}'.format(tensor_model_parallel_size))
     tensor_model_parallel_size = mpu.get_tensor_model_parallel_world_size()
@@ -210,37 +214,37 @@ def test_column_parallel_linear(tensor_model_parallel_size):
     my_dLdA = torch.split(dLdA, output_size_coeff,
                           dim=0)[rank].contiguous().clone()
     error = my_dLdA.sub(linear_layer.weight.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   error in dLdA on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     my_dLdb = torch.split(dLdb, output_size_coeff,
                           dim=0)[rank].contiguous().clone()
     error = my_dLdb.sub(linear_layer.bias.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   error in dLdb on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     error = dLdX.sub(identity_layer.weight.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   error in dLdX on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print(' >> passed the test :-)')
 
 
 def test_row_parallel_linear(tensor_model_parallel_size):
 
     mpu.initialize_model_parallel(tensor_model_parallel_size)
-    if torch.distributed.get_rank() == 0:
+    if dist.get_rank() == 0:
         print('> testing RowParallelLinear with model parallel '
               'size: {}'.format(tensor_model_parallel_size))
     tensor_model_parallel_size = mpu.get_tensor_model_parallel_world_size()
@@ -277,28 +281,29 @@ def test_row_parallel_linear(tensor_model_parallel_size):
     my_dLdA = torch.split(dLdA, input_size_coeff,
                           dim=1)[rank].contiguous().clone()
     error = my_dLdA.sub(linear_layer.weight.grad).abs().max()
-    torch.distributed.barrier()
+    dist = mcr_dl.get_distributed_engine()
+    dist.barrier()
     print('   error in dLdA on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     error = dLdb.sub(linear_layer.bias.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   error in dLdb on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     error = dLdX.sub(identity_layer.weight.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   error in dLdX on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 1.0e-6
 
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print(' >> passed the test :-)')
 
 
@@ -321,8 +326,8 @@ def parallel_self_attention(tensor_model_parallel_size, num_att_heads_per_partit
     seed = 12345
     set_random_seed(seed)
 
-    num_att_heads = num_att_heads_per_partition * \
-        torch.distributed.get_world_size()
+    dist = mcr_dl.get_distributed_engine()
+    num_att_heads = num_att_heads_per_partition * dist.get_world_size()
     hidden_size = hidden_size_per_att_head * num_att_heads
 
     # Network
@@ -347,7 +352,8 @@ def parallel_self_attention(tensor_model_parallel_size, num_att_heads_per_partit
 
 def test_parallel_self_attention(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing ParallelSelfAttention with model parallel '
               'size: {}'.format(tensor_model_parallel_size))
 
@@ -369,9 +375,9 @@ def test_parallel_self_attention(tensor_model_parallel_size):
     assert hideen_size_1 == hidden_size
 
     error = loss_1.sub(loss).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   loss error on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 5.0e-6
 
     my_lin_grad_list = torch.split(
@@ -380,20 +386,20 @@ def test_parallel_self_attention(tensor_model_parallel_size):
     my_lin_grad = torch.cat(my_lin_grad_list, dim=0)
     error = my_lin_grad.sub(
         attention_layer.query_key_value.weight.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   weight gradient error on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 5.0e-6
 
     error = identity_layer_1.weight.grad.sub(
         identity_layer.weight.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   input gradient error on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 5.0e-6
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print(' >> passed the test :-)')
 
 
@@ -406,8 +412,10 @@ def parallel_transformer(tensor_model_parallel_size, num_att_heads_per_partition
     seed = 12345
     set_random_seed(seed)
 
+    dist = mcr_dl.get_distributed_engine()
+
     num_att_heads = num_att_heads_per_partition * \
-        torch.distributed.get_world_size()
+        dist.get_world_size()
     hidden_size = hidden_size_per_att_head * num_att_heads
     intermediate_size = 4 * hidden_size
 
@@ -435,7 +443,8 @@ def parallel_transformer(tensor_model_parallel_size, num_att_heads_per_partition
 
 def test_parallel_transformer_layer(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing ParallelTransformerLayer with model parallel '
               'size: {}'.format(tensor_model_parallel_size))
 
@@ -455,20 +464,20 @@ def test_parallel_transformer_layer(tensor_model_parallel_size):
             hidden_size_per_att_head, batch_size, sequence_length)
 
     error = loss_1.sub(loss).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   loss error on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 5.0e-5, 'error: {}'.format(error)
 
     error = identity_layer_1.weight.grad.sub(
         identity_layer.weight.grad).abs().max()
-    torch.distributed.barrier()
+    dist.barrier()
     print('   input gradient error on global rank {}: {}'.format(
-        torch.distributed.get_rank(), error))
+        dist.get_rank(), error))
     assert error < 5.0e-5, 'error: {}'.format(error)
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print(' >> passed the test :-)')
 
 
@@ -478,7 +487,8 @@ if __name__ == '__main__':
     torch.backends.cudnn.benchmark = False
 
     initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+    dist = mcr_dl.get_distributed_engine()
+    world_size = dist.get_world_size()
 
     print_separator('test initialize affine weight')
     tensor_model_parallel_size = 1

--- a/megatron/mpu/tests/test_random.py
+++ b/megatron/mpu/tests/test_random.py
@@ -4,13 +4,15 @@ from commons import print_separator
 from commons import initialize_distributed
 import mpu
 import torch
+import mcr_dl
 import sys
 sys.path.append("../..")
 
 
 def test_set_cuda_rng_state(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing set_rng_state with size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -38,7 +40,7 @@ def test_set_cuda_rng_state(tensor_model_parallel_size):
     new_rng_state = torch.cuda.get_rng_state()
     max_diff = new_rng_state.sub(rng_state).max()
     print('   max diff in rng state (should be non-zero) on global rank {}: {}'.
-          format(torch.distributed.get_rank(), max_diff))
+          format(dist.get_rank(), max_diff))
     assert max_diff > 0
 
     # Reset the rng state and do the same stuff.
@@ -53,26 +55,27 @@ def test_set_cuda_rng_state(tensor_model_parallel_size):
     # Results should be the same
     error = result_2.sub(result_1).abs().max()
     print('   max error in generated tensors (should be zero) on '
-          'global rank {}: {}'.format(torch.distributed.get_rank(), error))
+          'global rank {}: {}'.format(dist.get_rank(), error))
     assert error < 1.0e-6
 
     # Input state should have remained intact.
     error = rng_state.sub(rng_state_copy).max()
     print('   max error in rng state (should be zero) on global rank {}: {}'.
-          format(torch.distributed.get_rank(), error))
+          format(dist.get_rank(), error))
     assert error == 0
 
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 def test_cuda_rng_tracker(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing cuda rng tracker with size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -120,14 +123,14 @@ def test_cuda_rng_tracker(tensor_model_parallel_size):
     diff = result_11.sub(result_21).abs().max()
     diff = min(diff, result_12.sub(result_22).abs().max())
     print('   max diff in generated tensors (should be non-zero) on '
-          'global rank {}: {}'.format(torch.distributed.get_rank(), diff))
+          'global rank {}: {}'.format(dist.get_rank(), diff))
     assert diff > 1.0e-6
     error = max(result_11.sub(target_11).abs().max(),
                 result_12.sub(target_12).abs().max())
     error = max(error, result_21.sub(target_21).abs().max())
     error = max(error, result_22.sub(target_22).abs().max())
     print('   max error in generated tensors (should be zero) on '
-          'global rank {}: {}'.format(torch.distributed.get_rank(), error))
+          'global rank {}: {}'.format(dist.get_rank(), error))
     assert error < 1.0e-6
 
     # Reset the tracker
@@ -136,14 +139,15 @@ def test_cuda_rng_tracker(tensor_model_parallel_size):
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 def test_model_parallel_cuda_manual_seed(tensor_model_parallel_size):
 
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         print('> testing model parallel cuda manual seed with size {} ...'.
               format(tensor_model_parallel_size))
 
@@ -162,15 +166,16 @@ def test_model_parallel_cuda_manual_seed(tensor_model_parallel_size):
     # Reset groups
     mpu.destroy_model_parallel()
 
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
+    dist.barrier()
+    if dist.get_rank() == 0:
         print('>> passed the test :-)')
 
 
 if __name__ == '__main__':
 
     initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+    dist = mcr_dl.get_distributed_engine()
+    world_size = dist.get_world_size()
 
     tensor_model_parallel_size = 1
     while tensor_model_parallel_size <= world_size:

--- a/megatron/text_generation/api.py
+++ b/megatron/text_generation/api.py
@@ -118,16 +118,18 @@ def generate(model,
 
     # Tokenize prompts and get the batch.
     # Note that these tensors are broadcaseted to all ranks.
-    if torch.distributed.get_rank() == 0:
+
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         assert prompts is not None
-    
+
     context_tokens_tensor, context_length_tensor = tokenize_prompts(
         prompts=prompts, tokens_to_generate=tokens_to_generate, add_BOS=add_BOS)
 
     if tokens_to_generate == 0:
         return score_and_return_on_first_stage(
             model, context_tokens_tensor, context_length_tensor)
-    
+
     # Main inference function.
     # Note that the outputs are available on the first stage.
     return generate_tokens_probs_and_return_on_first_stage(
@@ -167,7 +169,7 @@ def beam_search_and_post_process(model,
                                  prevent_newline_after_colon=prevent_newline_after_colon)
     # Only post-process on first stage.
     if mpu.is_pipeline_first_stage():
-        lengths = tokens.size(1)*torch.ones(beam_size, dtype=torch.int64, device=torch.cuda.current_device()) 
+        lengths = tokens.size(1)*torch.ones(beam_size, dtype=torch.int64, device=torch.cuda.current_device())
         tokens, prompts_plus_generations, prompts_plus_generations_segments = detokenize_generations(tokens, lengths, True)
         scores = scores.cpu().numpy().tolist()
         return prompts_plus_generations, prompts_plus_generations_segments, scores
@@ -194,7 +196,7 @@ def beam_search(model, prompts=None, tokens_to_generate=0, beam_size=0, add_BOS=
 
     context_tokens_tensor, context_length_tensor = tokenize_prompts(
         prompts=prompts, tokens_to_generate=tokens_to_generate, add_BOS=add_BOS)
-    
-    return beam_search_and_return_on_first_stage(model, context_tokens_tensor, context_length_tensor, 
+
+    return beam_search_and_return_on_first_stage(model, context_tokens_tensor, context_length_tensor,
             beam_size, stop_token=stop_token, num_return_gen=num_return_gen, length_penalty=length_penalty,
             prevent_newline_after_colon=prevent_newline_after_colon)

--- a/megatron/text_generation/communication.py
+++ b/megatron/text_generation/communication.py
@@ -4,6 +4,7 @@
 
 
 import torch
+import mcr_dl
 
 from megatron.core import mpu
 
@@ -15,10 +16,11 @@ def recv_from_prev_pipeline_rank_(recv_buffer=None):
     input buffer inplace."""
     if not mpu.is_pipeline_first_stage():
         assert recv_buffer is not None
-        recv_prev_op = torch.distributed.P2POp(
-            torch.distributed.irecv, recv_buffer,
+        dist = mcr_dl.get_distributed_engine()
+        recv_prev_op = dist.P2POp(
+            dist.irecv, recv_buffer,
             mpu.get_pipeline_model_parallel_prev_rank())
-        reqs = torch.distributed.batch_isend_irecv([recv_prev_op])
+        reqs = dist.batch_isend_irecv([recv_prev_op])
         for req in reqs:
             req.wait()
         # To protect against race condition when using batch_isend_irecv().
@@ -31,10 +33,11 @@ def send_to_next_pipeline_rank(tensor=None):
     """Send output to the next pipeline stage."""
     if not mpu.is_pipeline_last_stage():
         assert tensor is not None
-        send_next_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor,
+        dist = mcr_dl.get_distributed_engine()
+        send_next_op = dist.P2POp(
+            dist.isend, tensor,
             mpu.get_pipeline_model_parallel_next_rank())
-        reqs = torch.distributed.batch_isend_irecv([send_next_op])
+        reqs = dist.batch_isend_irecv([send_next_op])
         for req in reqs:
             req.wait()
         # To protect against race condition when using batch_isend_irecv().
@@ -74,7 +77,8 @@ def broadcast_from_last_pipeline_stage(size, dtype, tensor=None):
     # Get the group and corresponding source rank.
     src = mpu.get_pipeline_model_parallel_last_rank()
     group = mpu.get_pipeline_model_parallel_group()
-    torch.distributed.broadcast(tensor, src, group)
+    dist = mcr_dl.get_distributed_engine()
+    dist.broadcast(tensor, src, group)
 
     return tensor
 
@@ -100,7 +104,8 @@ def broadcast_from_last_to_first_pipeline_stage(size, dtype, tensor=None):
         src = mpu.get_pipeline_model_parallel_last_rank()
         group = mpu.get_embedding_group()
         # Broadcast from last stage into the first stage.
-        torch.distributed.broadcast(tensor, src, group)
+        dist = mcr_dl.get_distributed_engine()
+        dist.broadcast(tensor, src, group)
     else:
         tensor = None
 
@@ -134,7 +139,8 @@ def copy_from_last_to_first_pipeline_stage(size, dtype, tensor=None):
                                       dtype=dtype,
                                       device=torch.cuda.current_device())
         # Broadcast from last stage into the first stage.
-        torch.distributed.broadcast(tensor_, src, group)
+        dist = mcr_dl.get_distributed_engine()
+        dist.broadcast(tensor_, src, group)
         # Update the first stage tensor
         if is_first_stage and not is_contiguous:
             tensor[...] = tensor_
@@ -145,15 +151,15 @@ def broadcast_tensor(size, dtype, tensor=None, rank=0):
     """ Given size and type of a tensor on all ranks and the tensor value
         only on a specific rank, broadcast from that rank to all other ranks.
     """
-
-    if torch.distributed.get_rank() == rank:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == rank:
         _is_cuda_contiguous(tensor)
     else:
         tensor = torch.empty(size,
                              dtype=dtype,
                              device=torch.cuda.current_device())
 
-    torch.distributed.broadcast(tensor, rank)
+    dist.broadcast(tensor, rank)
 
     return tensor
 
@@ -163,7 +169,8 @@ def broadcast_list(size, dtype, list_values=None, rank=0):
     """Broadcast a list of values with a given type."""
 
     tensor = None
-    if torch.distributed.get_rank() == rank:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == rank:
         tensor = torch.tensor(list_values, dtype=dtype,
                               device=torch.cuda.current_device())
 

--- a/megatron/text_generation/tokenization.py
+++ b/megatron/text_generation/tokenization.py
@@ -4,7 +4,7 @@
 
 
 import torch
-
+import mcr_dl
 
 from megatron import get_tokenizer, get_args
 from .communication import broadcast_int_list, broadcast_tensor
@@ -30,7 +30,7 @@ def detokenize_generations(tokens_gpu_tensor,
         if return_segments:
             words = []
             for token in sequence_tokens:
-                if args.tokenizer_type in ['SentencePieceTokenizer', 
+                if args.tokenizer_type in ['SentencePieceTokenizer',
                         'GPTSentencePieceTokenizer']:
                     word = tokenizer.decoder[token]
                 elif args.tokenizer_type == 'NullTokenizer':
@@ -58,9 +58,10 @@ def tokenize_prompts(prompts=None, tokens_to_generate=None,
     sizes_list = None
     prompts_tokens_cuda_long_tensor = None
     prompts_length_cuda_long_tensor = None
+    dist = mcr_dl.get_distributed_engine()
 
     # On the specified rank, build the above.
-    if torch.distributed.get_rank() == rank:
+    if dist.get_rank() == rank:
         assert prompts is not None
         assert tokens_to_generate is not None
         # Tensor of tokens padded and their unpadded length.

--- a/megatron/text_generation_server.py
+++ b/megatron/text_generation_server.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 import datetime
 import torch
+import mcr_dl
 import json
 import threading
 from flask import Flask, request, jsonify, current_app
@@ -21,22 +22,24 @@ class MegatronGenerate(Resource):
     @staticmethod
     def send_do_generate():
         choice = torch.cuda.LongTensor([GENERATE_NUM])
-        torch.distributed.broadcast(choice, 0)
-     
+        dist = mcr_dl.get_distributed_engine()
+        dist.broadcast(choice, 0)
+
     @staticmethod
     def send_do_beam_search():
         choice = torch.cuda.LongTensor([BEAM_NUM])
-        torch.distributed.broadcast(choice, 0)
-    
+        dist = mcr_dl.get_distributed_engine()
+        dist.broadcast(choice, 0)
+
     def put(self):
         args = get_args()
-       
+
         if not "prompts" in request.get_json():
             return "prompts argument required", 400
-        
+
         if "max_len" in request.get_json():
             return "max_len is no longer used.  Replace with tokens_to_generate", 400
-        
+
         if "sentences" in request.get_json():
             return "sentences is no longer used.  Replace with prompts", 400
 
@@ -46,10 +49,10 @@ class MegatronGenerate(Resource):
 
         if len(prompts) == 0:
             return "prompts is empty", 400
-        
+
         if len(prompts) > 128:
             return "Maximum number of prompts is 128", 400
-        
+
         tokens_to_generate = 64  # Choosing hopefully sane default.  Full sequence is slow
         if "tokens_to_generate" in request.get_json():
             tokens_to_generate = request.get_json()["tokens_to_generate"]
@@ -63,10 +66,10 @@ class MegatronGenerate(Resource):
             logprobs = request.get_json()["logprobs"]
             if not isinstance(logprobs, bool):
                 return "logprobs must be a boolean value"
-        
+
         if tokens_to_generate == 0 and not logprobs:
             return "tokens_to_generate=0 implies logprobs should be True"
-        
+
         temperature = 1.0
         if "temperature" in request.get_json():
             temperature = request.get_json()["temperature"]
@@ -74,7 +77,7 @@ class MegatronGenerate(Resource):
                 return "temperature must be a positive number less than or equal to 100.0"
             if not (0.0 < temperature <= 100.0):
                 return "temperature must be a positive number less than or equal to 100.0"
-        
+
         top_k = 0.0
         if "top_k" in request.get_json():
             top_k = request.get_json()["top_k"]
@@ -82,7 +85,7 @@ class MegatronGenerate(Resource):
                 return "top_k must be an integer equal to or greater than 0 and less than or equal to 1000"
             if not (0 <= top_k <= 1000):
                 return "top_k must be equal to or greater than 0 and less than or equal to 1000"
-        
+
         top_p = 0.0
         if "top_p" in request.get_json():
             top_p = request.get_json()["top_p"]
@@ -92,7 +95,7 @@ class MegatronGenerate(Resource):
                 return "cannot set both top-k and top-p samplings."
             if not (0 <= top_p <= 1.0):
                 return "top_p must be less than or equal to 1.0"
-        
+
         top_p_decay = 0.0
         if "top_p_decay" in request.get_json():
             top_p_decay = request.get_json()["top_p_decay"]
@@ -102,7 +105,7 @@ class MegatronGenerate(Resource):
                 return "top_p_decay cannot be set without top_p"
             if not (0 <= top_p_decay <= 1.0):
                 return "top_p_decay must be less than or equal to 1.0"
-        
+
         top_p_bound = 0.0
         if "top_p_bound" in request.get_json():
             top_p_bound = request.get_json()["top_p_bound"]
@@ -112,13 +115,13 @@ class MegatronGenerate(Resource):
                 return "top_p_bound cannot be set without top_p"
             if not (0.0 < top_p_bound <= top_p):
                 return "top_p_bound must be greater than 0 and less than top_p"
-        
+
         add_BOS = False
         if "add_BOS" in request.get_json():
             add_BOS = request.get_json()["add_BOS"]
             if not isinstance(add_BOS, bool):
                 return "add_BOS must be a boolean value"
-        
+
         if any([len(prompt) == 0 for prompt in prompts]) and not add_BOS:
             return "Empty prompts require add_BOS=true"
 
@@ -127,7 +130,7 @@ class MegatronGenerate(Resource):
             stop_on_double_eol = request.get_json()["stop_on_double_eol"]
             if not isinstance(stop_on_double_eol, bool):
                 return "stop_on_double_eol must be a boolean value"
-        
+
         stop_on_eol = False
         if "stop_on_eol" in request.get_json():
             stop_on_eol = request.get_json()["stop_on_eol"]
@@ -145,7 +148,7 @@ class MegatronGenerate(Resource):
             random_seed = request.get_json()["random_seed"]
             if not isinstance(random_seed, int):
                 return "random_seed must be integer"
-            if random_seed < 0: 
+            if random_seed < 0:
                 return "random_seed must be a positive integer"
 
         no_log = False
@@ -153,7 +156,7 @@ class MegatronGenerate(Resource):
             no_log = request.get_json()["no_log"]
             if not isinstance(no_log, bool):
                 return "no_log must be a boolean value"
-        
+
         beam_width = None
         if "beam_width" in request.get_json():
             beam_width = request.get_json()["beam_width"]
@@ -169,20 +172,20 @@ class MegatronGenerate(Resource):
             stop_token = request.get_json()["stop_token"]
             if not isinstance(stop_token, int):
                 return "stop_token must be an integer"
-        
-        length_penalty = 1 
+
+        length_penalty = 1
         if "length_penalty" in request.get_json():
             length_penalty = request.get_json()["length_penalty"]
             if not isinstance(length_penalty, float):
                 return "length_penalty must be a float"
-        
+
         with lock:  # Need to get lock to keep multiple threads from hitting code
-            
+
             if not no_log:
                 print("request IP: " + str(request.remote_addr))
                 print(json.dumps(request.get_json()),flush=True)
                 print("start time: ", datetime.datetime.now())
-            
+
             try:
                 if beam_width is not None:
                     MegatronGenerate.send_do_beam_search()  # Tell other ranks we're doing beam_search
@@ -198,7 +201,7 @@ class MegatronGenerate(Resource):
                         length_penalty=length_penalty,
                         prevent_newline_after_colon=prevent_newline_after_colon
                         )
-                    
+
                     return jsonify({"text": response,
                         "segments": response_seg,
                         "scores": response_scores})
@@ -229,13 +232,13 @@ class MegatronGenerate(Resource):
             except ValueError as ve:
                 return ve.args[0]
             print("end time: ", datetime.datetime.now())
-        
+
 
 class MegatronServer(object):
     def __init__(self, model):
         self.app = Flask(__name__, static_url_path='')
         api = Api(self.app)
         api.add_resource(MegatronGenerate, '/api', resource_class_args=[model])
-        
-    def run(self, url): 
+
+    def run(self, url):
         self.app.run(url, threaded=True, debug=False)

--- a/megatron/timers.py
+++ b/megatron/timers.py
@@ -206,7 +206,15 @@ class Timers:
             dist._all_gather_base(rank_name_to_time.view(-1),
                                             rank_name_to_time[rank, :].view(-1))
         except:
-            all_gather_func = dist.allgather_fn
+            # Changes to support all_gather with MCR_DL
+            from megatron import get_args
+            args = get_args()
+            if args.distributed_engine == "torch":
+                from mcr_dl import TorchBackend
+                all_gather_func = TorchBackend.get_all_gather_function()
+            elif args.distributed_engine == "mcr_dl":
+                all_gather_func = dist.allgather_fn
+
             all_gather_func(rank_name_to_time.view(-1),
                                             rank_name_to_time[rank, :].view(-1))
 

--- a/pretrain_ict.py
+++ b/pretrain_ict.py
@@ -6,7 +6,7 @@ from functools import partial
 import math
 
 import torch
-import torch.distributed as dist
+import mcr_dl
 import torch.nn.functional as F
 
 from megatron import get_args
@@ -36,8 +36,9 @@ def pretrain_ict_model_provider(pre_process=True, post_process=True):
 def get_group_world_size_rank():
 
     group = mpu.get_data_parallel_group()
-    rank = torch.distributed.get_rank(group=group)
-    world_size = torch.distributed.get_world_size(group=group)
+    dist = mcr_dl.get_distributed_engine()
+    rank = dist.get_rank(group=group)
+    world_size = dist.get_world_size(group=group)
 
     return group, rank, world_size
 
@@ -51,7 +52,8 @@ class AllgatherFromDataParallelRegion(torch.autograd.Function):
 
         tensor_list = [torch.empty_like(input_) for _ in range(world_size)]
         tensor_list[rank] = input_
-        torch.distributed.all_gather(tensor_list, input_, group=group)
+        dist = mcr_dl.get_distributed_engine()
+        dist.all_gather(tensor_list, input_, group=group)
 
         output = torch.cat(tensor_list, dim=0).contiguous()
 

--- a/pretrain_vision_dino.py
+++ b/pretrain_vision_dino.py
@@ -4,7 +4,6 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 import numpy as np
-import torch.distributed as dist
 from functools import partial
 from megatron import get_args, get_timers, print_rank_0
 from megatron.core.enums import ModelType
@@ -37,7 +36,7 @@ def get_batch(data_iterator):
 
 def loss_func(model, labels, output_tensor, collect_data=False):
     args = get_args()
-    
+
     model = unwrap_model(
         model,
         (torchDDP, LocalDDP, Float16Module)

--- a/tasks/eval_utils.py
+++ b/tasks/eval_utils.py
@@ -7,6 +7,7 @@ import time
 from functools import partial
 
 import torch
+import mcr_dl
 
 from megatron import get_args
 from megatron import print_rank_last, is_last_rank
@@ -160,7 +161,8 @@ def calculate_correct_answers(name, model, dataloader,
     # Reduce.
     if mpu.is_pipeline_last_stage():
         unreduced = torch.cuda.LongTensor([correct, total])
-        torch.distributed.all_reduce(unreduced,
+        dist = mcr_dl.get_distributed_engine()
+        dist.all_reduce(unreduced,
                                      group=mpu.get_data_parallel_group())
 
         # Print on screen.

--- a/tasks/finetune_utils.py
+++ b/tasks/finetune_utils.py
@@ -5,6 +5,7 @@
 from functools import partial
 import sys
 import torch
+import mcr_dl
 
 from megatron import get_args, get_num_microbatches
 from megatron import print_rank_0
@@ -102,7 +103,7 @@ def _build_infinite_size_dataloader(dataloader):
             iterator = dataloader.__iter__()
 
 
-def _build_train_valid_dataloaders(train_dataset, valid_dataset, 
+def _build_train_valid_dataloaders(train_dataset, valid_dataset,
     task_collate_fn=None):
     """Traing and validation dataloaders."""
     args = get_args()
@@ -222,7 +223,8 @@ def _train(model, optimizer, opt_param_scheduler, forward_step,
             if args.exit_interval and iteration % args.exit_interval == 0:
                 if not saved_checkpoint:
                     save_checkpoint(iteration, model, optimizer, opt_param_scheduler)
-                torch.distributed.barrier()
+                dist = mcr_dl.get_distributed_engine()
+                dist.barrier()
                 print_rank_0('exiting program at iteration {}'.format(iteration))
                 sys.exit()
 

--- a/tasks/orqa/evaluate_utils.py
+++ b/tasks/orqa/evaluate_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
 import torch
+import mcr_dl
 
 from megatron import get_args, print_rank_0
 from megatron.checkpointing import load_biencoder_checkpoint
@@ -53,7 +54,7 @@ class ORQAEvaluator(object):
 
     def faiss_wrapper(self):
         # Initialize FAISS wrapper on local rank = 0 as the evidence embeddings
-        # is distributed over all the GPUs in a node and FAISS is not 
+        # is distributed over all the GPUs in a node and FAISS is not
         # thread-safe
         args = get_args()
         if args.local_rank == 0:
@@ -66,7 +67,8 @@ class ORQAEvaluator(object):
                                         use_gpu=self.faiss_use_gpu)
 
         # Wait for the FAISS index to be initialized in all the nodes
-        torch.distributed.barrier()
+        dist = mcr_dl.get_distributed_engine()
+        dist.barrier()
 
     def generate_query_vectors(self, qa_data, split):
 
@@ -88,7 +90,7 @@ class ORQAEvaluator(object):
 
             with torch.no_grad():
                 query_logits = unwrapped_model.embed_text(
-                    unwrapped_model.query_model, query_tokens, 
+                    unwrapped_model.query_model, query_tokens,
                     query_mask, query_types)
 
             reference_list.extend(reference)
@@ -106,31 +108,32 @@ class ORQAEvaluator(object):
         args = get_args()
         query_tensor, reference_list = self.generate_query_vectors(qa_data, \
                                                                     split)
+        dist = mcr_dl.get_distributed_engine()
         local_rank = args.local_rank
-        rank = torch.distributed.get_rank()
+        rank = dist.get_rank()
         device_count = torch.cuda.device_count()
-        num_nodes = torch.distributed.get_world_size() // device_count
+        num_nodes = dist.get_world_size() // device_count
         node_id = rank // device_count
 
         for node in range(num_nodes):
             start_rank = node * device_count
             end_rank = (node + 1) * device_count
             ranks_list = list(range(start_rank, end_rank))
-            node_group = torch.distributed.new_group(ranks=ranks_list)
+            node_group = dist.new_group(ranks=ranks_list)
 
             if node_id == node:
                 device_start_rank = start_rank
                 group = node_group
-        
+
         input_ = torch.empty_like(query_tensor).copy_(query_tensor).detach_()
         tensor_list = [torch.empty_like(input_) for _ in range(device_count)]
-        torch.distributed.all_gather(tensor_list, query_tensor, group=group)
+        dist.all_gather(tensor_list, query_tensor, group=group)
 
         if local_rank == 0 and self.mips_index is not None:
             all_query_tensor = torch.cat(tensor_list, dim=0).contiguous()
 
             distance, topkindex = self.mips_index.search_mips_index(
-                all_query_tensor, top_k=args.faiss_topk_retrievals, 
+                all_query_tensor, top_k=args.faiss_topk_retrievals,
                 reconstruct=False)
             distance = torch.from_numpy(distance).cuda()
             topkindex = torch.LongTensor(topkindex).cuda()
@@ -141,9 +144,9 @@ class ORQAEvaluator(object):
             topkindex = torch.empty(device_count * len(query_tensor), \
                 args.faiss_topk_retrievals, dtype=torch.int64).cuda()
 
-        torch.distributed.broadcast(distance, src=device_start_rank, \
+        dist.broadcast(distance, src=device_start_rank, \
             group=group)
-        torch.distributed.broadcast(topkindex, src=device_start_rank, \
+        dist.broadcast(topkindex, src=device_start_rank, \
             group=group)
 
         distance = torch.split(distance, len(query_tensor), dim=0)\

--- a/tasks/vision/classification/eval_utils.py
+++ b/tasks/vision/classification/eval_utils.py
@@ -6,6 +6,7 @@ import os
 from functools import partial
 
 import torch
+import mcr_dl
 
 from megatron import get_args
 from megatron import print_rank_0, print_rank_last
@@ -107,7 +108,8 @@ def calculate_correct_answers(model, dataloader, epoch):
     # Reduce.
     if mpu.is_pipeline_last_stage():
         unreduced = torch.cuda.LongTensor([correct, total])
-        torch.distributed.all_reduce(unreduced,
+        dist = mcr_dl.get_distributed_engine()
+        dist.all_reduce(unreduced,
                                      group=mpu.get_data_parallel_group())
 
         # Print on screen.

--- a/tasks/vision/segmentation/finetune_segformer.py
+++ b/tasks/vision/segmentation/finetune_segformer.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import torch
+import mcr_dl
 import torch.nn.functional as F
 from functools import partial
 from megatron import get_args, get_timers
@@ -91,7 +92,7 @@ def segmentation():
         logits = output_tensor.contiguous().float()
         logits = resize(logits, size=masks.shape[1:],
                         mode='bilinear', align_corners=False)
-      
+
         # Cross-entropy loss.
         # weight = calculate_weight(masks, num_classes)
         loss = F.cross_entropy(logits, masks, ignore_index=ignore_index)
@@ -183,7 +184,8 @@ def segmentation():
         # Reduce.
         if mpu.is_pipeline_last_stage():
             performs_tensor = torch.cuda.FloatTensor(performs)
-            torch.distributed.all_reduce(performs_tensor,
+            dist = mcr_dl.get_distributed_engine()
+            dist.all_reduce(performs_tensor,
                                          group=mpu.get_data_parallel_group())
             hist = performs_tensor.cpu().numpy()
             iu, acc, acc_cls = calculate_iou(hist)

--- a/tasks/zeroshot_gpt/evaluate.py
+++ b/tasks/zeroshot_gpt/evaluate.py
@@ -5,6 +5,7 @@
 import math
 
 import torch
+import mcr_dl
 
 from megatron import get_args
 from megatron import print_rank_0, is_last_rank
@@ -130,8 +131,9 @@ def evaluate(data_loader, model, eval_metric):
 
             # Reduce across processes.
             if parallel_state.is_pipeline_last_stage():
-                torch.distributed.all_reduce(output,
-                                             group=parallel_state.get_data_parallel_group())
+                dist = mcr_dl.get_distributed_engine()
+                dist.all_reduce(output,
+                                group=parallel_state.get_data_parallel_group())
 
                 total_output += output
 

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import mcr_dl
 import megatron.core.parallel_state as ps
 
 class Utils:
@@ -15,16 +16,23 @@ class Utils:
         master_ip = os.getenv('MASTER_ADDR', 'localhost')
         master_port = os.getenv('MASTER_PORT', '6000')
         init_method += master_ip + ':' + master_port
-        torch.distributed.init_process_group(backend='nccl', world_size=Utils.world_size, rank=Utils.rank, init_method=init_method)
-        
+        # dist = mcr_dl.get_distributed_engine()
+        # dist.init_process_group(backend='nccl', world_size=Utils.world_size, rank=Utils.rank, init_method=init_method)
+        mcr_dl.init_processes(dist_engine='torch', dist_backend='nccl',
+                              world_size=Utils.world_size, rank=Utils.rank,
+                              init_method=init_method)
+
+
     @staticmethod
     def destroy_model_parallel():
         ps.destroy_model_parallel()
-        torch.distributed.barrier()
+        dist = mcr_dl.get_distributed_engine()
+        dist.barrier()
 
     @staticmethod
     def initialize_model_parallel(tensor_model_parallel_size = 1, pipeline_model_parallel_size = 1, virtual_pipeline_model_parallel_size = None, pipeline_model_parallel_split_rank = None):
         ps.destroy_model_parallel()
-        if not torch.distributed.is_initialized():
+        dist = mcr_dl.get_distributed_engine()
+        if not dist.is_initialized():
             Utils.initialize_distributed()
         ps.initialize_model_parallel(tensor_model_parallel_size, pipeline_model_parallel_size, virtual_pipeline_model_parallel_size, pipeline_model_parallel_split_rank)

--- a/tools/bert_embedding/utils.py
+++ b/tools/bert_embedding/utils.py
@@ -5,6 +5,7 @@ import glob
 import numpy as np
 import os
 import torch
+import mcr_dl
 from tqdm import tqdm
 
 from megatron import print_rank_0
@@ -92,7 +93,8 @@ def get_missing_blocks(workdir, n_samples, block_size,
     all_block_path_set = set(block["path"] for block in all_blocks)
 
     # Delete corrupt files.
-    if torch.distributed.get_rank() == 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() == 0:
         existing_block_paths = [block["path"]
                                 for block in all_blocks
                                 if os.path.exists(block["path"])]
@@ -117,7 +119,7 @@ def get_missing_blocks(workdir, n_samples, block_size,
                 f.close()
 
     # Wait for files to be deleted.
-    torch.distributed.barrier()
+    dist.barrier()
 
     # Filter missing files.
     missing_blocks = [block
@@ -148,8 +150,8 @@ def get_missing_blocks_by_rank(workdir, n_samples, block_size,
     # Extend rank's missing blocks (with None) such that all ranks have equal
     # length lists. This allows for easier tracking of global progress.
     n_missing_tensor = torch.cuda.LongTensor([len(rank_missing_blocks)])
-    torch.distributed.all_reduce(n_missing_tensor,
-                                 op=torch.distributed.ReduceOp.MAX)
+    dist = mcr_dl.get_distributed_engine()
+    dist.all_reduce(n_missing_tensor, op=dist.ReduceOp.MAX)
     max_n_missing = n_missing_tensor.item()
     rank_missing_blocks += [None] * (max_n_missing - len(rank_missing_blocks))
 

--- a/tools/retro/db/build.py
+++ b/tools/retro/db/build.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import threading
 import torch
+import mcr_dl
 from tqdm import tqdm
 import types
 
@@ -95,9 +96,11 @@ def build_partial_db(
     doc_start_id = doc_range[0] + proc_id * n_docs_per_proc
     doc_end_id = min(doc_range[1], doc_start_id + n_docs_per_proc)
 
+    dist = mcr_dl.get_distributed_engine()
+
     # Print progress.
     progress_proc_ids = set(range(n_procs)) \
-        if torch.distributed.get_rank() == 0 else set()
+        if dist.get_rank() == 0 else set()
     if proc_id in progress_proc_ids:
         print(" > building partial chunk db, proc %d / %d, docs %d:%d / %d."%(
             proc_id,
@@ -192,8 +195,10 @@ def build_individual_db(dataset_idx, n_datasets, dataset_info, tokenizers):
         validate=lambda f : f["chunks_valid"].shape == (0,) \
             or f["chunks_valid"].shape[1] == 4)
 
+    dist = mcr_dl.get_distributed_engine()
+
     # Prevent missing-path-write race condition.
-    torch.distributed.barrier()
+    dist.barrier()
 
     if not missing_db_blocks:
         return
@@ -273,7 +278,7 @@ def build_individual_db(dataset_idx, n_datasets, dataset_info, tokenizers):
 
             # Wait for all ranks to finish block.
             print_rank_0(" > waiting for all ranks to finish block.")
-            torch.distributed.barrier()
+            dist.barrier()
 
     print_rank_0(" > finished saving individual db.")
 
@@ -310,7 +315,9 @@ def update_chunk_counts(indexed_dataset_infos):
 
     args = get_retro_args()
 
-    if torch.distributed.get_rank() != 0:
+    dist = mcr_dl.get_distributed_engine()
+
+    if dist.get_rank() != 0:
         return
 
     # Data ratio sum (for setting index training chunks).
@@ -357,7 +364,8 @@ def update_chunk_counts(indexed_dataset_infos):
 def merge_dbs(indexed_dataset_infos, db_type):
     '''Merge individual DBs into single DB.'''
 
-    if torch.distributed.get_rank() != 0:
+    dist = mcr_dl.get_distributed_engine()
+    if dist.get_rank() != 0:
         return
 
     print(" > build %s chunk db." % db_type)
@@ -481,8 +489,10 @@ def build_db():
     # Build dbs.
     build_individual_dbs(indexed_dataset_infos)
 
+    dist = mcr_dl.get_distributed_engine()
+
     # Single-process going forward.
-    if torch.distributed.get_rank() != 0:
+    if dist.get_rank() != 0:
         return
 
     # Update n_chunks & save indexed dataset infos.

--- a/tools/retro/query/query.py
+++ b/tools/retro/query/query.py
@@ -5,6 +5,7 @@ import os
 import psutil
 import time
 import torch
+import mcr_dl
 from tqdm import tqdm
 
 from megatron import get_retro_args, print_rank_0
@@ -83,7 +84,7 @@ def query_embeddings(db_dataset, index,
         sample_dataset_idx = sample["dataset_idx"].item()
         sample_doc_ids = sample["doc_ids"].tolist()
         sample_doc_tuples = [(sample_dataset_idx, d) for d in sample_doc_ids]
-        
+
         # Get valid neighbors (!= -1).
         query_row = [ i for i in query_neighbor_ids[chunk_id-min_chunk_id]
                       if i >= 0 ]
@@ -213,7 +214,8 @@ def query_dataset_neighbors(db_dataset, query_dataset,
 
         # Synchronize progress across all ranks. (for easier observation)
         print_rank_0(" > waiting for other ranks to finish block.")
-        torch.distributed.barrier()
+        dist = mcr_dl.get_distributed_engine()
+        dist.barrier()
 
 
 def query_pretraining_neighbors():

--- a/tools/retro/query/retro_dataset.py
+++ b/tools/retro/query/retro_dataset.py
@@ -3,6 +3,7 @@
 import numpy as np
 import os
 import torch
+import mcr_dl
 
 from megatron import get_args, get_retro_args
 from tools.bert_embedding.utils import BlockPathMap
@@ -129,26 +130,27 @@ def get_retro_datasets(verify_sizes=True):
         # Verify num chunks.
         n_sample_chunks = len(chunk_dataset)
         n_neighbor_chunks = neighbor_path_map.max_idx
+        dist = mcr_dl.get_distributed_engine()
 
         if not os.path.isdir(neighbor_dir):
-            if torch.distributed.get_rank() == 0:
+            if dist.get_rank() == 0:
                 raise Exception("neighbor directory '%s' not found; please "
                                 "compare --train-samples, --seq-length, --seed, "
                                 "--eval-iters, and --eval-interval, with "
                                 "retro preprocessing args." %
                                 neighbor_dir)
-            torch.distributed.barrier()
+            dist.barrier()
             exit()
 
         if verify_sizes and n_sample_chunks != n_neighbor_chunks:
-            if torch.distributed.get_rank() == 0:
+            if dist.get_rank() == 0:
                 print("neighbor_dir : %s" % neighbor_dir)
                 print("neighbor_path_map : %s" % neighbor_path_map)
                 raise Exception("num sampled chunks (%d) != num neighbor chunks "
                                 "(%d); did you complete querying the entire "
                                 "pretraining dataset?"
                                 % (n_sample_chunks, n_neighbor_chunks))
-            torch.distributed.barrier()
+            dist.barrier()
             exit()
 
         # Retro dataset.

--- a/tools/run_text_generation_server.py
+++ b/tools/run_text_generation_server.py
@@ -17,6 +17,7 @@ from megatron.text_generation_server import MegatronServer
 from megatron.text_generation import generate_and_post_process
 from megatron.text_generation import beam_search_and_post_process
 import torch
+import mcr_dl
 
 def model_provider(pre_process=True, post_process=True):
     """Build the model."""
@@ -62,9 +63,10 @@ if __name__ == "__main__":
         server = MegatronServer(model)
         server.run("0.0.0.0")
 
+    dist = mcr_dl.get_distributed_engine()
     while True:
         choice = torch.cuda.LongTensor(1)
-        torch.distributed.broadcast(choice, 0)
+        dist.broadcast(choice, 0)
         if choice[0].item() == 0:
             try:
                 generate_and_post_process(model)


### PR DESCRIPTION
Integrating MCR-DL with Megatron-LM-v23.05  

(_Note : v23.05 is used for A100 GPUs, for latest version of Megatron-LM, please rebase this branch with main_)

- Verified integration changes on mri with config backend = 'nccl' distributed-engine = 'toch' for following benchmarks:
[pretrain_bert.sh](https://github.com/OSU-Nowlab/Megatron-LM/blob/main/examples/pretrain_bert.sh)
[pretrain_bert_distributed.sh](https://github.com/OSU-Nowlab/Megatron-LM/blob/main/examples/pretrain_bert_distributed.sh)

- To install mcr-dl : use [simplify-mcr-dl-access](https://github.com/OSU-Nowlab/MCR-DL/tree/simplify-mcr-dl-access ) (PR : https://github.com/OSU-Nowlab/MCR-DL/pull/17)

- Find the example sbatch script to run pretrain_bert_distributed.sh :
[distributed_run_pretrain_gpt.txt](https://github.com/OSU-Nowlab/Megatron-LM/files/15045363/distributed_run_pretrain_gpt.txt)


